### PR TITLE
Added system stash command

### DIFF
--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -35,3 +35,4 @@ twine
 
 # static type checking
 mypy
+types-mock

--- a/doc/source/commands.rst
+++ b/doc/source/commands.rst
@@ -5,3 +5,4 @@ Command Line
    :maxdepth: 1
 
    commands/system_stackbuild
+   commands/system_stash

--- a/doc/source/commands/system_stash.rst
+++ b/doc/source/commands/system_stash.rst
@@ -1,0 +1,41 @@
+kiwi-ng system stash
+====================
+
+SYNOPSIS
+--------
+
+.. code:: bash
+
+   kiwi-ng [global options] service <command> [<args>]
+
+   kiwi-ng system stash -h | --help
+   kiwi-ng system stash --root=<directory>
+       [--tag=<name>]
+   kiwi-ng system stash help
+
+DESCRIPTION
+-----------
+
+Create a container from the given root directory. The command
+takes the contents of the given root directory at call time
+and creates a container from it.
+
+OPTIONS
+-------
+
+--root=<directory>
+
+  The path to the root directory, usually the result of
+  a former system prepare or build call
+
+--tag=<name>
+
+  The tag name for the container. By default 'latest'
+  is used
+
+EXAMPLE
+-------
+
+.. code:: bash
+
+   $ kiwi-ng system stash --root /tmp/mytest/build/image-root

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -100,14 +100,22 @@ html_theme_options = {
 # -- Options for manual page output ---------------------------------------
 
 # The man page toctree documents.
-image_obs_doc = 'commands/system_stackbuild'
+system_stackbuild_doc = 'commands/system_stackbuild'
+system_stash_doc = 'commands/system_stash'
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
     (
-        image_obs_doc,
+        system_stackbuild_doc,
         'kiwi::system::stackbuild',
+        'Stack Build Plugin',
+        [author],
+        8
+    ),
+    (
+        system_stash_doc,
+        'kiwi::system::stash',
         'Stack Build Plugin',
         [author],
         8

--- a/kiwi_stackbuild_plugin/defaults.py
+++ b/kiwi_stackbuild_plugin/defaults.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2021 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms owf the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+
+from kiwi.defaults import Defaults
+from typing import (
+    Dict, List
+)
+
+
+class StackBuildDefaults:
+    """
+    **Implements stackbuild default values**
+
+    Provides static methods for default values and state information
+    """
+    @staticmethod
+    def get_stash_home() -> str:
+        """
+        Provides the base directory to store stash containers
+
+        :return: dir path name
+
+        :rtype: str
+        """
+        return os.path.join(
+            os.environ.get('HOME') or '', '.config', 'kiwi_stash'
+        )
+
+    @staticmethod
+    def get_stash_exclude_list() -> List:
+        """
+        Provides the list of folders that are not relevant
+        for the image root stash
+
+        :return: list of file and directory names
+
+        :rtype: list
+        """
+        return [
+            'dev/*',
+            'sys/*',
+            'proc/*'
+        ]
+
+    @staticmethod
+    def get_container_config(
+        container_name: str, tag: str, maintainer: str
+    ) -> Dict:
+        """
+        Provides the container config used for the stash
+        created container
+
+        :return: container config dict
+
+        :rtype: dict
+        """
+        preparer = Defaults.get_preparer()
+        return {
+            'container_name': container_name,
+            'container_tag': tag,
+            'entry_command': ['/bin/sh'],
+            'labels': {
+                'io.osinside.kiwi.maintainer': maintainer,
+                'io.osinside.kiwi.meta': preparer
+            },
+            'history': {
+                'created_by': preparer,
+                'comment': 'KIWI Root Tree Stash',
+                'author': maintainer
+            }
+        }

--- a/kiwi_stackbuild_plugin/tasks/system_stash.py
+++ b/kiwi_stackbuild_plugin/tasks/system_stash.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2021 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms owf the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+"""
+usage: kiwi-ng system stash -h | --help
+       kiwi-ng system stash --root=<directory>
+           [--tag=<name>]
+       kiwi-ng system stash help
+
+commands:
+    stash
+        create a container from the given root directory
+    stash help
+        show manual page for stash command
+
+options:
+    --root=<directory>
+        the path to the root directory, usually the result of
+        a former system prepare or build call
+    --tag=<name>
+        the tag name for the container.
+        By default set to: latest
+"""
+import os
+import logging
+
+from kiwi.help import Help
+from kiwi.tasks.base import CliTask
+from kiwi.privileges import Privileges
+from kiwi.xml_description import XMLDescription
+from kiwi.xml_state import XMLState
+from kiwi.oci_tools import OCI
+from kiwi.path import Path
+
+from kiwi_stackbuild_plugin.defaults import StackBuildDefaults
+
+log = logging.getLogger('kiwi')
+
+
+class SystemStashTask(CliTask):
+    def process(self) -> None:
+        if self.command_args.get('help') is True:
+            self.manual = Help()
+            return self.manual.show('kiwi::system::stash')
+
+        Privileges.check_for_root_permissions()
+
+        log.info('Reading Image description')
+        description = XMLDescription(
+            os.path.join(self.command_args['--root'], 'image', 'config.xml')
+        )
+        xml_state = XMLState(
+            xml_data=description.load()
+        )
+        contact_info = xml_state.get_description_section()
+        stash_target_dir = SystemStashTask._create_stash_target_dir(
+            self.command_args['--root'],
+            xml_state.xml_data.get_name()
+        )
+
+        stash_container_file_name = os.path.join(
+            stash_target_dir, 'stash.tar'
+        )
+        stash_container_tag = self.command_args['--tag'] or 'latest'
+        container_config = StackBuildDefaults.get_container_config(
+            os.path.basename(stash_container_file_name),
+            stash_container_tag,
+            contact_info.author
+        )
+        log.info('Initializing stash container')
+        oci = OCI.new()
+        if os.path.exists(stash_container_file_name):
+            log.info('--> Adding new layer on existing stash')
+            oci.import_container_image(
+                f'oci-archive:{stash_container_file_name}:{stash_container_tag}'
+            )
+        else:
+            log.info('--> Creating initial layer')
+            oci.init_container()
+
+        oci.unpack()
+        oci.sync_rootfs(
+            self.command_args['--root'],
+            StackBuildDefaults.get_stash_exclude_list()
+        )
+        oci.repack(container_config)
+        oci.post_process()
+        log.info('Exporting stash container')
+        oci.export_container_image(
+            stash_container_file_name, 'oci-archive', stash_container_tag
+        )
+
+    @staticmethod
+    def _create_stash_target_dir(root_dir: str, image_name: str) -> str:
+        stash_target_dir = os.path.join(
+            StackBuildDefaults.get_stash_home(),
+            os.path.abspath(root_dir).replace(os.sep, '_'),
+            image_name
+        )
+        Path.create(stash_target_dir)
+        return stash_target_dir

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ config = {
     'packages': ['kiwi_stackbuild_plugin'],
     'entry_points': {
         'kiwi.tasks': [
-            'system_stackbuild=kiwi_stackbuild_plugin.tasks.system_stackbuild'
+            'system_stackbuild=kiwi_stackbuild_plugin.tasks.system_stackbuild',
+            'system_stash=kiwi_stackbuild_plugin.tasks.system_stash'
         ]
     },
     'include_package_data': True,

--- a/test/data/image-root/image/config.xml
+++ b/test/data/image-root/image/config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image name="tumbleweed" schemaversion="7.4">
+    <description type="system">
+        <author>Marcus Schaefer</author>
+        <contact>ms@suse.com</contact>
+        <specification>Some Image</specification>
+    </description>
+    <preferences>
+        <keytable>us</keytable>
+        <locale>en_US</locale>
+        <packagemanager>zypper</packagemanager>
+        <timezone>Europe/Berlin</timezone>
+        <version>1.99.1</version>
+        <type image="tbz"/>
+    </preferences>
+    <users>
+        <user groups="root" home="/root" name="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0"/>
+    </users>
+    <repository alias="Tumbleweed" imageinclude="true">
+        <source path="http://download.opensuse.org/tumbleweed/repo/oss"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+    </packages>
+</image>

--- a/test/unit/tasks/system_stash_test.py
+++ b/test/unit/tasks/system_stash_test.py
@@ -1,0 +1,103 @@
+import sys
+from mock import (
+    Mock, patch
+)
+
+from kiwi_stackbuild_plugin.tasks.system_stash import SystemStashTask
+
+
+class TestSystemStashTask:
+    def setup(self):
+        sys.argv = [
+            sys.argv[0], 'system', 'stash',
+            '--root', 'some-root-dir'
+        ]
+        self.task = SystemStashTask()
+
+    def _init_command_args(self):
+        self.task.command_args = {}
+        self.task.command_args['help'] = False
+        self.task.command_args['stash'] = False
+        self.task.command_args['--root'] = None
+        self.task.command_args['--tag'] = None
+
+    @patch('kiwi_stackbuild_plugin.tasks.system_stash.Help')
+    def test_process_help(self, mock_Help):
+        Help = Mock()
+        mock_Help.return_value = Help
+        self._init_command_args()
+        self.task.command_args['help'] = True
+        self.task.command_args['stash'] = True
+        self.task.process()
+        Help.show.assert_called_once_with(
+            'kiwi::system::stash'
+        )
+
+    @patch('kiwi_stackbuild_plugin.tasks.system_stash.OCI.new')
+    @patch('kiwi_stackbuild_plugin.tasks.system_stash.Privileges')
+    @patch('kiwi_stackbuild_plugin.tasks.system_stash.Path')
+    @patch('os.path.exists')
+    @patch('os.path.abspath')
+    def test_process_build_initial_layer(
+        self, mock_os_path_abspath, mock_os_path_exists,
+        mock_Path, mock_Privileges, mock_OCI_new
+    ):
+        self._init_command_args()
+        self.task.command_args['--root'] = '../data/image-root'
+        oci = Mock()
+        mock_OCI_new.return_value = oci
+        mock_os_path_exists.return_value = False
+        mock_os_path_abspath.return_value = 'absolute_root_dir_path'
+        with patch.dict('os.environ', {'HOME': '../data'}):
+            self.task.process()
+            mock_Privileges.check_for_root_permissions.assert_called_once_with()
+            oci.init_container.assert_called_once_with()
+            oci.unpack.assert_called_once_with()
+            oci.sync_rootfs.assert_called_once_with(
+                '../data/image-root', ['dev/*', 'sys/*', 'proc/*']
+            )
+            oci.repack.assert_called_once_with(
+                {
+                    'container_name': 'stash.tar',
+                    'container_tag': 'latest',
+                    'entry_command': ['/bin/sh'],
+                    'labels': {
+                        'io.osinside.kiwi.maintainer': 'Marcus Schaefer',
+                        'io.osinside.kiwi.meta':
+                            'KIWI - https://github.com/OSInside/kiwi'
+                    },
+                    'history': {
+                        'created_by':
+                            'KIWI - https://github.com/OSInside/kiwi',
+                            'comment': 'KIWI Root Tree Stash',
+                            'author': 'Marcus Schaefer'
+                    }
+                }
+            )
+            oci.post_process.assert_called_once_with()
+            oci.export_container_image.assert_called_once_with(
+                '../data/.config/kiwi_stash/absolute_root_dir_path/'
+                'tumbleweed/stash.tar', 'oci-archive', 'latest'
+            )
+
+    @patch('kiwi_stackbuild_plugin.tasks.system_stash.OCI.new')
+    @patch('kiwi_stackbuild_plugin.tasks.system_stash.Privileges')
+    @patch('kiwi_stackbuild_plugin.tasks.system_stash.Path')
+    @patch('os.path.exists')
+    @patch('os.path.abspath')
+    def test_process_build_additional_layer(
+        self, mock_os_path_abspath, mock_os_path_exists,
+        mock_Path, mock_Privileges, mock_OCI_new
+    ):
+        self._init_command_args()
+        self.task.command_args['--root'] = '../data/image-root'
+        oci = Mock()
+        mock_OCI_new.return_value = oci
+        mock_os_path_exists.return_value = True
+        mock_os_path_abspath.return_value = 'absolute_root_dir_path'
+        with patch.dict('os.environ', {'HOME': '../data'}):
+            self.task.process()
+            oci.import_container_image.assert_called_once_with(
+                'oci-archive:../data/.config/kiwi_stash/'
+                'absolute_root_dir_path/tumbleweed/stash.tar:latest'
+            )

--- a/tox.ini
+++ b/tox.ini
@@ -52,8 +52,8 @@ changedir=test/unit
 commands =
     bash -c 'cd ../../ && ./setup.py develop'
     bash -c 'cd ../../ && mypy kiwi_stackbuild_plugin test/unit'
-#    pytest --no-cov-on-fail --cov=kiwi_stackbuild_plugin \
-#        --cov-report=term-missing \
+    pytest --no-cov-on-fail --cov=kiwi_stackbuild_plugin \
+        --cov-report=term-missing
 #        --cov-fail-under=100 {posargs}
 
 
@@ -72,8 +72,8 @@ changedir=test/unit
 commands =
     bash -c 'cd ../../ && ./setup.py develop'
     bash -c 'cd ../../ && mypy kiwi_stackbuild_plugin test/unit'
-#    pytest --doctest-modules --no-cov-on-fail --cov=kiwi_stackbuild_plugin \
-#        --cov-report=term-missing \
+    pytest --doctest-modules --no-cov-on-fail --cov=kiwi_stackbuild_plugin \
+        --cov-report=term-missing
 #        --cov-fail-under=100 {posargs}
 
 # Documentation build suitable for local review


### PR DESCRIPTION
The system stash command allows to create a container image
from a given root tree. The result can be considered a cache
file for the stackbuild command.