### PR TITLE
setup.py: Drop unused dependency on "mock"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ config = {
     'license' : 'GPLv3+',
     'install_requires': [
         'docopt',
-        'mock',
         'kiwi>=9.23.0'
     ],
     'packages': ['kiwi_stackbuild_plugin'],


### PR DESCRIPTION
This is only used for tests, which is handled elsewhere.