### PR TITLE
Adding support for a new Stackbuild specific schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,14 @@ install:
 	install -m 644 README.rst \
 		${buildroot}${docdir}/python-kiwi_stackbuild_plugin/README
 
+kiwi_stackbuild_plugin/schema.rng: kiwi_stackbuild_plugin/schema.rnc
+	# whenever the schema is changed this target will convert
+	# the short form of the RelaxNG schema to the format used
+	# in code and auto generates the python data structures
+	@type -p trang &>/dev/null || \
+		(echo "ERROR: trang not found in path: $(PATH)"; exit 1)
+	trang -I rnc -O rng kiwi_stackbuild_plugin/schema.rnc kiwi_stackbuild_plugin/schema.rng
+
 build: clean tox
 	# create setup.py variant for rpm build.
 	# delete module versions from setup.py for building an rpm

--- a/kiwi_stackbuild_plugin/defaults.py
+++ b/kiwi_stackbuild_plugin/defaults.py
@@ -16,6 +16,8 @@
 # along with kiwi-stackbuild.  If not, see <http://www.gnu.org/licenses/>
 #
 import re
+import importlib
+from importlib.resources import as_file
 
 from kiwi.defaults import Defaults
 from typing import (
@@ -95,3 +97,31 @@ class StackBuildDefaults:
                 'author': maintainer
             }
         }
+
+    @staticmethod
+    def project_file(filename):
+        """
+        Provides the python module base directory search path
+
+        The method uses the importlib.resources.path method to identify
+        files and directories from the application
+
+        :param string filename: relative project file
+
+        :return: absolute file path name
+
+        :rtype: str
+        """
+        with as_file(importlib.resources.files('kiwi_stackbuild_plugin')) as path:
+            return f'{path}/{filename}'
+
+    @staticmethod
+    def get_schema_file():
+        """
+        Provides file path to kiwi RelaxNG schema
+
+        :return: file path
+
+        :rtype: str
+        """
+        return StackBuildDefaults.project_file('schema.rng')

--- a/kiwi_stackbuild_plugin/exceptions.py
+++ b/kiwi_stackbuild_plugin/exceptions.py
@@ -41,3 +41,10 @@ class KiwiStackBuildPluginRootSyncFailed(KiwiError):
     Exception raised if the rsync process to sync the stash into
     the root-tree failed
     """
+
+
+class KiwiStackBuildPluginSchemaValidationFailed(KiwiError):
+    """
+    Exception raised if the provided XML description is not compliant with
+    the stack build image schema
+    """

--- a/kiwi_stackbuild_plugin/kiwi-fake-schema.rnc
+++ b/kiwi_stackbuild_plugin/kiwi-fake-schema.rnc
@@ -1,0 +1,9 @@
+#==========================================
+# Fake rnc file used only to convert
+# stackbuild schema.rnc file to schema.rng
+# without requiring the actual KIWI schema
+# file
+#
+start =
+    ## The start pattern of an image
+    k.image

--- a/kiwi_stackbuild_plugin/kiwi-fake-schema.rng
+++ b/kiwi_stackbuild_plugin/kiwi-fake-schema.rng
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://relaxng.org/ns/structure/1.0">
+  <!--
+    ==========================================
+    Fake rnc file used only to convert
+    stackbuild schema.rnc file to schema.rng
+    without requiring the actual KIWI schema
+    file
+    
+  -->
+  <start>
+    <ref name="k.image">
+      <a:documentation>The start pattern of an image</a:documentation>
+    </ref>
+  </start>
+</grammar>

--- a/kiwi_stackbuild_plugin/schema.rnc
+++ b/kiwi_stackbuild_plugin/schema.rnc
@@ -1,0 +1,56 @@
+#================
+# FILE          : schema.rnc
+#****************
+# PROJECT       : KIWI - Stack Build Plugin
+# COPYRIGHT     : (c) 2021 SUSE LINUX Products GmbH
+#               :
+# AUTHOR        : David Cassany <dcassany@suse.com>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : This is the RELAX NG Schema for KIWI Rebuild Images
+#               : plugin configuration files. The schema is maintained
+#               : in the relax compact syntax. Any changes should
+#               : made in !! *** schema.rnc *** !!
+#               :
+#               :
+# STATUS        : Development
+#****************
+
+namespace rng = "http://relaxng.org/ns/structure/1.0"
+
+# The real include value is computed and replaced in memory at runtime
+# to match the actual KIWI schema of the KIWI module being loaded
+include "kiwi-fake-schema.rnc" {
+    k.image.schemaversion.attribute =
+        ## The allowed Schema version (fixed value)
+        attribute schemaversion { "0.1" }
+
+    k.image.attlist = k.image.name.attribute
+        & k.image.stackbuild.attribute
+        & k.image.displayname.attribute?
+        & k.image.id?
+        & k.image.schemaversion.attribute
+        & ( k.image.noNamespaceSchemaLocation.attribute?
+            | k.image.schemaLocation.attribute? )?
+
+    k.image =
+        ## The root element of the configuration file
+        element image {
+            k.image.attlist &
+            k.description? &
+            k.preferences* &
+            k.profiles? &
+            k.users* &
+            k.drivers* &
+            k.strip* &
+            k.repository* &
+            k.packages* 
+        }
+}
+
+div{
+    k.image.stackbuild.attribute =
+        ## Identifies description as a stackbuild XML
+        attribute stackbuild { "true" }
+}

--- a/kiwi_stackbuild_plugin/schema.rng
+++ b/kiwi_stackbuild_plugin/schema.rng
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ================
+  FILE          : schema.rnc
+  ****************
+  PROJECT       : KIWI - Stack Build Plugin
+  COPYRIGHT     : (c) 2021 SUSE LINUX Products GmbH
+                :
+  AUTHOR        : David Cassany <dcassany@suse.com>
+                :
+  BELONGS TO    : Operating System images
+                :
+  DESCRIPTION   : This is the RELAX NG Schema for KIWI Rebuild Images
+                : plugin configuration files. The schema is maintained
+                : in the relax compact syntax. Any changes should
+                : made in !! *** schema.rnc *** !!
+                :
+                :
+  STATUS        : Development
+  ****************
+-->
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns="http://relaxng.org/ns/structure/1.0">
+  <!--
+    The real include value is computed and replaced in memory at runtime
+    to match the actual KIWI schema of the KIWI module being loaded
+  -->
+  <include href="kiwi-fake-schema.rng">
+    <define name="k.image.schemaversion.attribute">
+      <attribute name="schemaversion">
+        <a:documentation>The allowed Schema version (fixed value)</a:documentation>
+        <value>0.1</value>
+      </attribute>
+    </define>
+    <define name="k.image.attlist">
+      <interleave>
+        <ref name="k.image.name.attribute"/>
+        <ref name="k.image.stackbuild.attribute"/>
+        <optional>
+          <ref name="k.image.displayname.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.image.id"/>
+        </optional>
+        <ref name="k.image.schemaversion.attribute"/>
+        <optional>
+          <choice>
+            <optional>
+              <ref name="k.image.noNamespaceSchemaLocation.attribute"/>
+            </optional>
+            <optional>
+              <ref name="k.image.schemaLocation.attribute"/>
+            </optional>
+          </choice>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.image">
+      <element name="image">
+        <a:documentation>The root element of the configuration file</a:documentation>
+        <interleave>
+          <ref name="k.image.attlist"/>
+          <optional>
+            <ref name="k.description"/>
+          </optional>
+          <zeroOrMore>
+            <ref name="k.preferences"/>
+          </zeroOrMore>
+          <optional>
+            <ref name="k.profiles"/>
+          </optional>
+          <zeroOrMore>
+            <ref name="k.users"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="k.drivers"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="k.strip"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="k.repository"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="k.packages"/>
+          </zeroOrMore>
+        </interleave>
+      </element>
+    </define>
+  </include>
+  <div>
+    <define name="k.image.stackbuild.attribute">
+      <attribute name="stackbuild">
+        <a:documentation>Identifies description as a stackbuild XML</a:documentation>
+        <value>true</value>
+      </attribute>
+    </define>
+  </div>
+</grammar>

--- a/kiwi_stackbuild_plugin/tasks/system_stash.py
+++ b/kiwi_stackbuild_plugin/tasks/system_stash.py
@@ -89,7 +89,9 @@ class SystemStashTask(CliTask):
         )
         description = XMLDescription(kiwi_description)
         xml_state = XMLState(
-            xml_data=description.load()
+            description.load(),
+            self.global_args['--profile'],
+            self.global_args['--type']
         )
         contact_info = xml_state.get_description_section()
         image_name = self.command_args['--container-name'] or \

--- a/kiwi_stackbuild_plugin/xml_merge.py
+++ b/kiwi_stackbuild_plugin/xml_merge.py
@@ -1,0 +1,333 @@
+# Copyright (c) 2021 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi-stackbuild.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms owf the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+from lxml import etree
+import os
+import glob
+import logging
+
+from kiwi.utils.sync import DataSync
+from kiwi.defaults import Defaults
+from kiwi.exceptions import (
+    KiwiConfigFileNotFound
+)
+
+from kiwi_stackbuild_plugin.defaults import StackBuildDefaults
+from kiwi_stackbuild_plugin.exceptions import (
+    KiwiStackBuildPluginSchemaValidationFailed
+)
+
+log = logging.getLogger('kiwi')
+
+
+class XMLMerge:
+    """
+    ***Implements the class to handle stackbuild schema and descriptions.
+    Converts a given stackbuild description into a full KIWI description
+    based on the stashed KIWI description***
+
+    :param str description_dir: the folder path contianing the stackbuild
+        description XML
+    """
+    def __init__(self, description_dir: str):
+        self.description = self._find_description_file(description_dir)
+        self.description_dir = description_dir
+        self.description_tree = etree.parse(self.description)
+
+    def is_stackbuild_description(self) -> bool:
+        """
+        Returns True if the root element includes the 'stackbuild="true"'
+        attribute
+
+        :returns: True if the stackbuild attribute is found, False otherwise
+
+        :rtype: bool
+        """
+        root = self.description_tree.getroot()
+        if 'stackbuild' in root.attrib and root.attrib['stackbuild'] == 'true':
+            return True
+        return False
+
+    def validate_schema(self) -> None:
+        """
+        Runs the stackbuild schema validation, raises a
+        'KiwiStackBuildPluginSchemaValidationFailed' exception
+        if the validation fails
+        """
+        schema_file = StackBuildDefaults.get_schema_file()
+        log.info('Loading stack build schema')
+        schema_tree = etree.parse(schema_file)
+        root = schema_tree.getroot()
+        kiwi_schema = Defaults.get_schema_file()
+        rngns = root.nsmap['rng']
+        for child in root.iter():
+            if child.tag == f'{{{rngns}}}include':
+                log.debug(f'Setting stack build schema to include kiwi schema: {kiwi_schema}')
+                child.set('href', kiwi_schema)
+                break
+
+        relaxng = etree.RelaxNG(schema_tree)
+        validation_rng = relaxng.validate(self.description_tree)
+
+        if not validation_rng:
+            raise KiwiStackBuildPluginSchemaValidationFailed(f'Failed to validate schema: {relaxng.error_log}')
+
+    def merge_description(self, derived_from_dir: str, target_dir: str) -> None:
+        """
+        Merges a stackbuild description with the KIWI description found
+        in the given path. The original description is copied to the target
+        directory and then the stackbuild description is applied on top.
+
+        :param str derived_from_dir: path of the KIWI description to update
+            with the stackbuild description
+        :param str target_dir: path where the merged description is stored
+        """
+        sync = DataSync(os.path.join(derived_from_dir, ''), target_dir)
+        sync.sync_data(options=Defaults.get_sync_options())
+
+        derived_from = self._find_description_file(target_dir)
+        work_tree = etree.parse(derived_from)
+
+        self._image_merge(work_tree)
+        self._description_replace(work_tree)
+        self._preferences_merge(work_tree)
+        self._profiles_merge(work_tree)
+        self._users_merge(work_tree)
+        self._drop_in_sections(work_tree)
+
+        sync = DataSync(f'{self.description_dir}/', target_dir)
+        sync.sync_data(options=Defaults.get_sync_options())
+
+        work_tree.write(derived_from, pretty_print=True)
+
+    def _description_replace(self, work_tree):
+        """
+        Replaces the description section of the original KIWI description
+        with the one provided by the stackbuild description if any
+
+        :param work_tree: parsed etree of the original KIWI description
+            to modify
+        """
+        self._replace_unique_element_by_xpath(
+            work_tree, '/image/description[@type="system"]'
+        )
+
+    def _drop_in_sections(self, work_tree):
+        """
+        Adds all sections in stackbuild description to the given etree
+        except for 'description', 'preferences' and 'profiles' which require
+        an specific merge logic
+
+        :param work_tree: parsed etree of the original KIWI description
+            to modify
+        """
+        root = self.description_tree.getroot()
+        w_root = work_tree.getroot()
+        exclude_list = ['description', 'preferences', 'profiles']
+        for item in root:
+            if item.tag not in exclude_list:
+                w_root.append(item)
+
+    def _replace_unique_element_by_xpath(self, work_tree, xpath):
+        """
+        Replaces an element found in the current stackbuild etree to the
+        given etree. The element is refrenced and located with a given xpath
+
+        :param work_tree: parsed etree of the original KIWI description
+            to modify
+        :param str xpath: the xpath to identify and locate the element to replace
+
+        :return: true or false
+
+        :rtype: bool
+        """
+        replacement = self.description_tree.xpath(xpath)
+        if len(replacement):
+            obsolete = work_tree.xpath(xpath)
+            if len(obsolete):
+                parent = obsolete[0].getparent()
+                parent.replace(obsolete[0], replacement[0])
+                return True
+        return False
+
+    def _profiles_merge(self, work_tree):
+        """
+        Appends or replaces the profiles included within the stackbuild description
+        to the given working elementTree based on the original KIWI description
+
+        :param work_tree: parsed etree of the original KIWI description
+            to modify
+        """
+        profiles = self.description_tree.xpath('/image/profiles')
+        if len(profiles):
+            w_profiles = work_tree.xpath('/image/profiles')
+            if len(w_profiles):
+                for profile in profiles[0]:
+                    name = profile.attrib['name']
+                    if not self._replace_unique_element_by_xpath(
+                        work_tree,
+                        f'/image/profiles/profile[@name=\'{name}\']'
+                    ):
+                        w_profiles[0].append(profile)
+            else:
+                work_tree.getroot().append(profiles[0])
+
+    def _preferences_merge(self, work_tree):
+        """
+        Combines the preferences available in the stackbuild description
+        with the originial KIWI description. Stackbuild preferences are simply
+        appended or combined to the original depending on attribures set
+        of each preferences element. If a stackbuild preferences element includes
+        the same set of attributes of another prefences element present in the
+        original description they are combined. Otherwise the stackbuild
+        element is simply appended to the original KIWI description.
+
+        :param work_tree: parsed etree of the original KIWI description
+            to modify
+        """
+        preferences = self.description_tree.xpath('/image/preferences')
+        for preferences_set in preferences:
+            pref = self._element_with_attributes_exists(
+                work_tree, '/image/preferences', preferences_set.attrib
+            )
+            if pref is None:
+                work_tree.getroot().append(preferences_set)
+            else:
+                self._merge_preferences_set(preferences_set, pref)
+
+    def _element_with_attributes_exists(self, tree, e_path, attributes):
+        """
+        Check if it exists an elemental in the given tree matches the given
+        path and attributes. Returns the first matching element or None if
+        there is no match.
+
+        :param tree: etree to evaluate
+        :param str e_path: the path used to match elements
+        :param attributes: the set of attributes to match
+
+        :return: The first etree element matching with the given path
+            and attributes. Returns None if no match
+        """
+        attr_list = [f'@{k}=\'{v}\'' for k, v in attributes.items()]
+        constraints = '[not(@*)]'
+        if attr_list:
+            constraints = '[' + ' and '.join(attr_list) + ']'
+        item = tree.xpath(e_path + constraints)
+        if len(item):
+            return item[0]
+        return None
+
+    def _merge_preferences_set(self, pref_setA, pref_setB):
+        """
+        Combines the two given preferences sets. A is applied over
+        B. Any child element in A that is missing B is appended to B. Any
+        child element in A that is already existing in B is replace in B
+        with the contents of A. The rule has a couple of exceptions:
+
+          * 'type' elements are only replaced if they also match the image type
+          * 'showlicense' elements are only appended, they can't be replaced
+
+        :param pref_setA: a preferences element tree object
+        :param pref_setB: a preferences element tree object
+        """
+        for child in pref_setA:
+            if child.tag == 'showlicense':
+                pref_setB.append(child)
+                continue
+            if child.tag == 'type':
+                b_type = self._element_with_attributes_exists(
+                    pref_setB, './type', {'image': child.attrib['image']}
+                )
+                if b_type is None:
+                    pref_setB.append(child)
+                else:
+                    pref_setB.replace(b_type, child)
+                continue
+            b_child = pref_setB.xpath(f'./{child.tag}')
+            if len(b_child):
+                pref_setB.replace(b_child[0], child)
+            else:
+                pref_setB.append(child)
+
+    def _find_description_file(self, description_directory):
+        """
+        Finds a description XML file in given directory
+
+        :param str description_directory: the directory path to evaluate
+
+        :return: the found XML description file
+
+        :rtype: str
+        """
+        config_file = description_directory + '/config.xml'
+        log.debug(f'looking for XML description file {config_file}')
+        if os.path.exists(config_file):
+            return config_file
+
+        log.debug(f'{config_file} not found...')
+        glob_match = description_directory + '/*.kiwi'
+        log.debug(f'looking for XML description file {glob_match}')
+        for config_file in sorted(glob.iglob(glob_match)):
+            return config_file
+
+        raise KiwiConfigFileNotFound(
+            'no XML description found in %s' % description_directory
+        )
+
+    def _image_merge(self, work_tree):
+        """
+        Replaces or adds the stackbuild image attributes to the
+        original KIWI description image root element.
+
+        :param work_tree: parsed etree of the original KIWI description
+            to modify
+        """
+        img = self.description_tree.getroot()
+        w_root = work_tree.getroot()
+        if 'displayname' in img.attrib:
+            w_root.attrib['displayname'] = img.attrib['displayname']
+        if 'id' in img.attrib:
+            w_root.attrib['id'] = img.attrib['id']
+        if 'name' in img.attrib:
+            w_root.attrib['name'] = img.attrib['name']
+
+    def _users_merge(self, work_tree):
+        """
+        Appends or replaces users from the stackbuild description to the
+        original KIWI description. The criteria to replace users is based on
+        users name. If a user name defined in stackbuild description already
+        exists in the KIWI description this gets replaced.
+
+        :param work_tree: parsed etree of the original KIWI description
+            to modify
+        """
+        users = self.description_tree.xpath('/image/users')
+        for users_sec in users:
+            usrs_match = self._element_with_attributes_exists(
+                work_tree, '/image/users', users_sec.attrib
+            )
+            if usrs_match is None:
+                work_tree.getroot().append(users_sec)
+            else:
+                for user in users_sec:
+                    usr_match = self._element_with_attributes_exists(
+                        usrs_match, './user', {'name': user.attrib['name']}
+                    )
+                    if usr_match is None:
+                        usrs_match.append(user)
+                    else:
+                        usrs_match.replace(usr_match, user)

--- a/test/data/kiwi-description/alternate-config.kiwi
+++ b/test/data/kiwi-description/alternate-config.kiwi
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image name="tumbleweed" schemaversion="7.4">
+    <description type="system">
+        <author>Marcus Schaefer</author>
+        <contact>ms@suse.com</contact>
+        <specification>Some Image</specification>
+    </description>
+    <preferences>
+        <keytable>us</keytable>
+        <locale>en_US</locale>
+        <packagemanager>zypper</packagemanager>
+        <timezone>Europe/Berlin</timezone>
+        <version>1.99.1</version>
+        <type image="tbz"/>
+    </preferences>
+    <users>
+        <user groups="root" home="/root" name="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0"/>
+    </users>
+    <repository alias="Tumbleweed" imageinclude="true">
+        <source path="http://download.opensuse.org/tumbleweed/repo/oss"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+    </packages>
+</image>

--- a/test/data/kiwi-description/config.xml
+++ b/test/data/kiwi-description/config.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image name="tumbleweed" schemaversion="7.4">
+    <description type="system">
+        <author>Marcus Schaefer</author>
+        <contact>ms@suse.com</contact>
+        <specification>Some Image</specification>
+    </description>
+    <profiles>
+        <profile name="Virtual" description="Simple Disk image"/>
+    </profiles>
+    <preferences>
+        <keytable>us</keytable>
+        <locale>en_US</locale>
+        <packagemanager>zypper</packagemanager>
+        <timezone>Europe/Berlin</timezone>
+        <version>1.99.1</version>
+        <type image="tbz"/>
+    </preferences>
+    <users>
+        <user groups="root" home="/root" name="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0"/>
+    </users>
+    <repository alias="Tumbleweed" imageinclude="true">
+        <source path="http://download.opensuse.org/tumbleweed/repo/oss"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+    </packages>
+</image>

--- a/test/data/stackbuild-description/config.kiwi
+++ b/test/data/stackbuild-description/config.kiwi
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image name="tumbleweed" schemaversion="0.1" stackbuild="true" displayname="test name" id="ID">
+    <description type="system">
+        <author>David Cassany</author>
+        <contact>dcassany@suse.com</contact>
+        <specification>Some variation of an stashed image</specification>
+    </description>
+    <profiles>
+        <profile name="Live" description="Live image"/>
+    </profiles>
+    <preferences profiles="Live">
+        <keytable>us</keytable>
+        <locale>en_US</locale>
+        <packagemanager>zypper</packagemanager>
+        <timezone>Europe/Berlin</timezone>
+        <version>1.99.1</version>
+        <type image="iso"/>
+    </preferences>
+    <preferences>
+        <keytable>us</keytable>
+        <locale>en_US</locale>
+        <packagemanager>zypper</packagemanager>
+        <timezone>Europe/Berlin</timezone>
+        <version>1.99.1</version>
+        <type image="tbz"/>
+        <type image="oem"/>
+        <showlicense>MY_LICENSE</showlicense>
+        <release-version>1.1</release-version>
+    </preferences>
+    <users>
+        <user groups="root" home="/root" name="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0"/>
+        <user groups="users" home="/home" name="newuser" password="$1$oQ2X7Mgu$UiWB4C9jfFvUKygpvT9WY0"/>
+    </users>
+    <users profiles="Live">
+        <user groups="users" home="/home" name="liveuser" password="$1$oQ2X7Mgu$UiWB4C9jfFvUKygpvT9WY0"/>
+    </users>
+    <packages type="image">
+        <package name="cowsay"/>
+    </packages>
+</image>

--- a/test/unit/xml_merge_test.py
+++ b/test/unit/xml_merge_test.py
@@ -1,0 +1,59 @@
+import shutil
+from pytest import raises
+from tempfile import mkdtemp
+from mock import patch
+
+from kiwi.exceptions import (
+    KiwiConfigFileNotFound
+)
+
+from kiwi_stackbuild_plugin.xml_merge import XMLMerge
+from kiwi_stackbuild_plugin.exceptions import (
+    KiwiStackBuildPluginSchemaValidationFailed
+)
+
+
+class TestXMLMerge:
+    def setup(self):
+        self.target_dir = mkdtemp(prefix='kiwi_desc_target.')
+
+    def setup_method(self, cls):
+        self.setup()
+
+    def teardown_method(self, cls):
+        shutil.rmtree(self.target_dir)
+
+    def test_XMLMerge_no_description(self):
+        with raises(KiwiConfigFileNotFound):
+            XMLMerge(self.target_dir)
+
+    def test_is_stackbuild_description(self):
+        xml_merge = XMLMerge('../data/stackbuild-description')
+        assert xml_merge.is_stackbuild_description()
+
+    def test_is_not_stackbuild_description(self):
+        xml_merge = XMLMerge('../data/kiwi-description')
+        assert not xml_merge.is_stackbuild_description()
+
+    def test_validate_schema(self):
+        xml_merge = XMLMerge('../data/stackbuild-description')
+        xml_merge.validate_schema()
+
+    def test_validate_schema_fails(self):
+        xml_merge = XMLMerge('../data/kiwi-description')
+        with raises(KiwiStackBuildPluginSchemaValidationFailed):
+            xml_merge.validate_schema()
+
+    @patch('kiwi_stackbuild_plugin.xml_merge.DataSync')
+    def test_merge_description(self, mock_DataSync):
+        shutil.copy('../data/kiwi-description/config.xml', self.target_dir)
+        xml_merge = XMLMerge('../data/stackbuild-description')
+        xml_merge.validate_schema()
+        xml_merge.merge_description('../data/kiwi-description', self.target_dir)
+
+    @patch('kiwi_stackbuild_plugin.xml_merge.DataSync')
+    def test_merge_description_without_profiles(self, mock_DataSync):
+        shutil.copy('../data/kiwi-description/alternate-config.kiwi', self.target_dir)
+        xml_merge = XMLMerge('../data/stackbuild-description')
+        xml_merge.validate_schema()
+        xml_merge.merge_description('../data/kiwi-description', self.target_dir)


### PR DESCRIPTION
This is adding a new schema type for stackbuild plugin on build commands. Descriptions provided by the `--description` flag are parsed to check if they include the `stackbuild` attribute at root level, if not it assumes this should be validated as a regular KIWI description, however if the `staclbuild="true"`  attribute is there the description is validated against the new schema.

The new schema is essentially the same as a regular KIWI description with the difference that any section under `<image>` is optional. Stackbuild schema can only be used against stashed images, which implies the stashed image already includes the KIWI description used at stash time. This new stackbuild schema is essentially used to replace or add sections to the stashed description. At build time the stackbuild description is applied on top of the stashed KIWI description to create a new full KIWI description. Then the build proceeds as a regular KIWI build (including XML validation).

This is useful to apply small modifications over an existing image without having to duplicate the whole description. Imagine adding extra packages, provide a new `<type>`, include extra users, etc. All other files of the description (e.g. `config.sh`) are rsynced on top of the stashed description. Hence the original is preserved or replaced, new ones could also be included this way.