### PR TITLE
Replace usage of mock with standard library version

### DIFF
--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -14,9 +14,6 @@ pytest
 pytest-cov
 pytest-xdist
 
-# Rolling backport of unittest.mock for all Pythons
-mock
-
 # Version-bump your software with a single command!
 bumpversion
 
@@ -35,4 +32,3 @@ twine
 
 # static type checking
 mypy
-types-mock

--- a/kiwi_stackbuild_plugin/tasks/system_stackbuild.py
+++ b/kiwi_stackbuild_plugin/tasks/system_stackbuild.py
@@ -63,7 +63,7 @@ options:
 import os
 import sys
 import logging
-from mock import patch
+from unittest.mock import patch
 from docopt import docopt
 from typing import (
     Dict, List

--- a/package/python-kiwi_stackbuild_plugin-spec-template
+++ b/package/python-kiwi_stackbuild_plugin-spec-template
@@ -80,7 +80,6 @@ image root directory
 Summary:        KIWI - Stack Build Plugin
 Group:          Development/Languages/Python
 Requires:       python%{python3_pkgversion}-docopt
-Requires:       python%{python3_pkgversion}-mock
 Requires:       python%{python3_pkgversion}-kiwi >= 9.21.21
 Requires:       python%{python3_pkgversion}-setuptools
 

--- a/test/unit/tasks/system_stackbuild_test.py
+++ b/test/unit/tasks/system_stackbuild_test.py
@@ -1,6 +1,6 @@
 import sys
 from pytest import raises
-from mock import (
+from unittest.mock import (
     Mock, patch, call
 )
 

--- a/test/unit/tasks/system_stash_test.py
+++ b/test/unit/tasks/system_stash_test.py
@@ -1,6 +1,6 @@
 import sys
 from pytest import raises
-from mock import (
+from unittest.mock import (
     Mock, patch
 )
 from tempfile import NamedTemporaryFile


### PR DESCRIPTION
We have no need for the rolling backport, as our needs are very simple.

Fixes: #6 
Fixes: #9 